### PR TITLE
chore: adicionando arquivo .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+end_of_line = lf
+
+[*.go]
+indent_style = tab
+indent_size = tab
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.scss]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
O [EditorConfig](https://editorconfig.org/) é um projeto que permite configurar editores de forma padronizada a partir de um mesmo arquivo de configuração.

Esse commit adiciona um arquivo `.editorconfig` com configurações padrões para o projeto.