### PR TITLE
build: arrumando a build da aplicação

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,16 @@ FROM golang:1.24
 # Defina o diretório de trabalho dentro do container
 WORKDIR /app
 
-RUN apt-get update ; apt-get install coreutils nodejs -y
+RUN apt-get update ; apt-get install coreutils nodejs npm -y
+
+COPY package*.json ./
+RUN npm install
 
 # Faça cache das dependências copiando go.mod e go.sum primeiro
 COPY go.* ./
 RUN go mod download
 RUN go install github.com/air-verse/air@latest
+
 # Copie o restante do código-fonte da aplicação
 COPY . .
 

--- a/cmd/start.sh
+++ b/cmd/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 sleep 10
+npm install
 node esbuild.js &
 /go/bin/air

--- a/local-compose-override.yml
+++ b/local-compose-override.yml
@@ -1,3 +1,5 @@
+volumes:
+  node_modules:
 services:
   app:
       build:
@@ -5,5 +7,6 @@ services:
         dockerfile: Dockerfile
       volumes:
       - ./:/app
+      - node_modules:/app/node_modules
       ports:
       - "${APP_PORT}:${APP_PORT}"

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ const (
 func main() {
 	r := mux.NewRouter()
 
-	r.HandleFunc("/health", HealthHandler).Methods("GET")
+	r.HandleFunc("/health", handlers.HealthHandler).Methods("GET")
 	r.PathPrefix(AssetsServerPath).Handler(http.StripPrefix(AssetsServerPath, http.FileServer(http.Dir(CompiledAssetsPath))))
 
 	log.Println("Rodando na porta: " + config.EnvVariables.AppPort)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "luciene",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Instala as dependências de Node no Dockerfile e no start.sh e usa um volume Docker para armazenar o `node_modules` de forma isolada da máquina.

Arruma também o import do `HealthHandler`.