### PR TITLE
chore: arrumando .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Formatação padrão de arquivos.
 1c04eeaaa23f114a28b528904c2b35f8732f80ba
+2dfaa9e4a970d7e8e27a6fbf1efd809925868827


### PR DESCRIPTION
O PR #78 foi mergeado com squash, então o commit que formatou os arquivos mudou para 2dfaa9e4a970d7e8e27a6fbf1efd809925868827.