### PR TITLE
feat(authors): Adiciona rota para formulário de novo autor

### DIFF
--- a/internal/handlers/authors.go
+++ b/internal/handlers/authors.go
@@ -25,8 +25,15 @@ func NewAuthorHandler(repo repository.AuthorRepository) *AuthorHandler {
 // DefineAuthors registra as rotas de autor no roteador.
 func (h *AuthorHandler) DefineAuthors(router *mux.Router) {
 	authorsRouter := router.PathPrefix("/authors").Subrouter()
+	authorsRouter.HandleFunc("/new", h.NewAuthorForm).Methods("GET")
 	authorsRouter.HandleFunc("/{id}", h.UpdateAuthor).Methods("PATCH")
 	authorsRouter.HandleFunc("", h.CreateAuthorHandler).Methods("POST")
+}
+
+// NewAuthorForm exibe o formulário para criar um novo autor.
+func (h *AuthorHandler) NewAuthorForm(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Rota GET /authors/new OK - o formulário de criação de autor será exibido aqui.\n"))
 }
 
 func (h *AuthorHandler) UpdateAuthor(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
closed #43 

A implementação segue o padrão de separar a responsabilidade de apresentação (GET) da de processamento de dados (POST /authors).

- Adicionada a rota `GET /authors/new` em `authors.go`.
- Implementado um handler placeholder `NewAuthorForm`.
- Criado um novo teste (`TestNewAuthorForm`) para garantir a cobertura da nova rota.
- Refatorado o teste `TestCreateAuthorHandler` para utilizar o roteador, simulando o comportamento real da aplicação de forma mais fiel.